### PR TITLE
Fix `GTLYouTubeResourceId` allocation

### DIFF
--- a/Source/Objects/GTLObject.m
+++ b/Source/Objects/GTLObject.m
@@ -528,10 +528,16 @@ static NSMutableDictionary *gKindMap = nil;
 
 + (BOOL)useDynamicMappingForClass:(Class)class
 {
-  static NSSet *excludedClasses;
+  static NSMutableSet *excludedClasses;
   static dispatch_once_t once;
   dispatch_once(&once, ^{
-    excludedClasses = [[NSSet alloc] initWithObjects:NSClassFromString(@"GTLYouTubeResourceId"), nil];
+    excludedClasses = [[NSMutableSet alloc] init];
+    for (NSString *excludedClassName in @[ @"GTLYouTubeResourceId" ]) {
+      Class excludedClass = NSClassFromString(excludedClassName);
+      if (excludedClass) {
+        [excludedClasses addObject:excludedClass];
+      }
+    }
   });
   return ![excludedClasses containsObject:class];
 }

--- a/Source/Objects/GTLObject.m
+++ b/Source/Objects/GTLObject.m
@@ -526,6 +526,16 @@ static NSMutableDictionary *gKindMap = nil;
   }
 }
 
++ (BOOL)useDynamicMappingForClass:(Class)class
+{
+  static NSSet *excludedClasses;
+  static dispatch_once_t once;
+  dispatch_once(&once, ^{
+    excludedClasses = [[NSSet alloc] initWithObjects:NSClassFromString(@"GTLYouTubeResourceId"), nil];
+  });
+  return ![excludedClasses containsObject:class];
+}
+
 #pragma mark Object Instantiation
 
 + (GTLObject *)objectForJSON:(NSMutableDictionary *)json
@@ -553,7 +563,7 @@ static NSMutableDictionary *gKindMap = nil;
   NSString *kind = nil;
   if ([json isKindOfClass:[NSDictionary class]]) {
     kind = [json valueForKey:@"kind"];
-    if ([kind isKindOfClass:[NSString class]] && [kind length] > 0) {
+    if ([kind isKindOfClass:[NSString class]] && [kind length] > 0 && [self useDynamicMappingForClass:defaultClass]) {
       Class dynamicClass = [GTLObject registeredObjectClassForKind:kind];
       if (dynamicClass) {
         classToCreate = dynamicClass;


### PR DESCRIPTION
Code that [allocates `GTLObject` instances](https://github.com/google/google-api-objectivec-client/blob/4e1c06132cc88ff81f31e280dc99a38a769603e0/Source/Objects/GTLObject.m#L554-L559) uses the `kind` key to determine which subclass should be allocated. This works well except for `GTLYouTubeResourceId` where the `kind` key doesn’t have the same meaning.

The following JSON excerpt allocates a `GTLYouTubeVideo` object instead of a `GTLYouTubeResourceId` object:

```json
"resourceId" : {
    "kind" : "youtube#video",
    "videoId" : "RjtCS0EEoCY"
}
```

Of course using something like `playlistItem.snippet.resourceId.videoId` crashes with the following exception: `-[GTLYouTubeVideo videoId]: unrecognized selector sent to instance 0x7fbce9545330`

This commit addresses this issue by ignoring the `kind` key for `GTLYouTubeResourceId` objects.

Fixes #63
Fixes #92