### PR TITLE
More work for supporting a single source to import fetch/oauth sources

### DIFF
--- a/Source/GTLDefines.h
+++ b/Source/GTLDefines.h
@@ -75,16 +75,18 @@
 #ifndef GTL_ASSERT
   // we directly invoke the NSAssert handler so we can pass on the varargs
   #if !defined(NS_BLOCK_ASSERTIONS)
-    #define GTL_ASSERT(condition, ...)                                       \
-      do {                                                                     \
-        if (!(condition)) {                                                    \
-          [[NSAssertionHandler currentHandler]                                 \
-              handleFailureInFunction:[NSString stringWithUTF8String:__PRETTY_FUNCTION__] \
-                                 file:[NSString stringWithUTF8String:__FILE__] \
-                           lineNumber:__LINE__                                 \
-                          description:__VA_ARGS__];                            \
-        }                                                                      \
-      } while(0)
+#define GTL_ASSERT(condition, ...)                                             \
+  do {                                                                         \
+    if (!(condition)) {                                                        \
+      [[NSAssertionHandler currentHandler]                                     \
+          handleFailureInFunction:                                             \
+              (NSString *)[NSString stringWithUTF8String:__PRETTY_FUNCTION__]  \
+                             file:(NSString *)[NSString                        \
+                                      stringWithUTF8String:__FILE__]           \
+                       lineNumber:__LINE__                                     \
+                      description:__VA_ARGS__];                                \
+    }                                                                          \
+  } while (0)
   #else
     #define GTL_ASSERT(condition, ...) do { } while (0)
   #endif // !defined(NS_BLOCK_ASSERTIONS)

--- a/Source/GTLNetworking_Sources.m
+++ b/Source/GTLNetworking_Sources.m
@@ -1,22 +1,39 @@
-#if defined(__has_feature) && __has_feature(objc_arc)
-#error "This file needs to be compiled with ARC disabled."
+#import <TargetConditionals.h>
+#import <AvailabilityMacros.h>
+
+#if (!TARGET_OS_IPHONE && defined(MAC_OS_X_VERSION_10_11) && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_11) \
+    || (TARGET_OS_IPHONE && defined(__IPHONE_9_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_9_0)
+  #ifndef GTM_USE_SESSION_FETCHER
+    #define GTM_USE_SESSION_FETCHER 1
+  #endif
 #endif
 
-#import "HTTPFetcher/GTMGatherInputStream.m"
-#import "HTTPFetcher/GTMMIMEDocument.m"
-#import "HTTPFetcher/GTMReadMonitorInputStream.m"
-#import "HTTPFetcher/GTMHTTPFetcher.m"
-#import "HTTPFetcher/GTMHTTPFetcherLogging.m"
-#import "HTTPFetcher/GTMHTTPFetcherService.m"
-#import "HTTPFetcher/GTMHTTPFetchHistory.m"
-#import "HTTPFetcher/GTMHTTPUploadFetcher.m"
+#if GTM_USE_SESSION_FETCHER
+  #if defined(__has_feature) && !__has_feature(objc_arc)
+  #error "This file needs to be compiled with ARC enabled."
+  #endif
 
-#import "OAuth2/GTMOAuth2Authentication.m"
-#import "OAuth2/GTMOAuth2SignIn.m"
-#if TARGET_OS_IPHONE
-  #import "OAuth2/Touch/GTMOAuth2ViewControllerTouch.m"
-#elif TARGET_OS_MAC
-  #import "OAuth2/Mac/GTMOAuth2WindowController.m"
+  #undef GTMSESSION_BUILD_COMBINED_SOURCES
+  #define GTMSESSION_BUILD_COMBINED_SOURCES 1
+
+  #import "HTTPFetcher/GTMGatherInputStream.m"
+  #import "HTTPFetcher/GTMMIMEDocument.m"
+  #import "HTTPFetcher/GTMReadMonitorInputStream.m"
+  #import "HTTPFetcher/GTMSessionFetcher.m"
+  #import "HTTPFetcher/GTMSessionFetcherLogging.m"
+  #import "HTTPFetcher/GTMSessionFetcherService.m"
+  #import "HTTPFetcher/GTMSessionUploadFetcher.m"
 #else
-  #error Need Target Conditionals
+  #if defined(__has_feature) && __has_feature(objc_arc)
+  #error "This file needs to be compiled with ARC disabled."
+  #endif
+
+  #import "HTTPFetcher/GTMGatherInputStream.m"
+  #import "HTTPFetcher/GTMMIMEDocument.m"
+  #import "HTTPFetcher/GTMReadMonitorInputStream.m"
+  #import "HTTPFetcher/GTMHTTPFetcher.m"
+  #import "HTTPFetcher/GTMHTTPFetcherLogging.m"
+  #import "HTTPFetcher/GTMHTTPFetcherService.m"
+  #import "HTTPFetcher/GTMHTTPFetchHistory.m"
+  #import "HTTPFetcher/GTMHTTPUploadFetcher.m"
 #endif

--- a/Source/GTLOAuth2_Sources.m
+++ b/Source/GTLOAuth2_Sources.m
@@ -1,0 +1,23 @@
+#import <TargetConditionals.h>
+#import <AvailabilityMacros.h>
+
+#if defined(__has_feature) && __has_feature(objc_arc)
+#error "This file needs to be compiled with ARC disabled."
+#endif
+
+#if (!TARGET_OS_IPHONE && defined(MAC_OS_X_VERSION_10_11) && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_11) \
+|| (TARGET_OS_IPHONE && defined(__IPHONE_9_0) && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_9_0)
+  #ifndef GTM_USE_SESSION_FETCHER
+    #define GTM_USE_SESSION_FETCHER 1
+  #endif
+#endif
+
+#import "OAuth2/GTMOAuth2Authentication.m"
+#import "OAuth2/GTMOAuth2SignIn.m"
+#if TARGET_OS_IPHONE
+  #import "OAuth2/Touch/GTMOAuth2ViewControllerTouch.m"
+#elif TARGET_OS_MAC
+  #import "OAuth2/Mac/GTMOAuth2WindowController.m"
+#else
+  #error Need Target Conditionals
+#endif


### PR DESCRIPTION
- compile-time macro to skip duplicate interface declarations.
- Add a wrapper file for the oauth sources.