### PR TITLE
Xcode 7.2 Updates

### DIFF
--- a/Source/GTLCore.xcodeproj/project.pbxproj
+++ b/Source/GTLCore.xcodeproj/project.pbxproj
@@ -109,37 +109,37 @@
 		4FDE227E1384818E005AEFAA /* GTLQuery.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FDE22541384818E005AEFAA /* GTLQuery.m */; };
 		4FDE227F1384818E005AEFAA /* GTLRuntimeCommon.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FDE22561384818E005AEFAA /* GTLRuntimeCommon.m */; };
 		4FDE22801384818E005AEFAA /* GTLService.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FDE22581384818E005AEFAA /* GTLService.m */; };
-		4FEE17A61C03DB5900A38758 /* GTMGatherInputStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FEE17981C03DB5900A38758 /* GTMGatherInputStream.h */; };
+		4FEE17A61C03DB5900A38758 /* GTMGatherInputStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FEE17981C03DB5900A38758 /* GTMGatherInputStream.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4FEE17A71C03DB5900A38758 /* GTMGatherInputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FEE17991C03DB5900A38758 /* GTMGatherInputStream.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		4FEE17A81C03DB5900A38758 /* GTMGatherInputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FEE17991C03DB5900A38758 /* GTMGatherInputStream.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		4FEE17A91C03DB5900A38758 /* GTMGatherInputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FEE17991C03DB5900A38758 /* GTMGatherInputStream.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		4FEE17AA1C03DB5900A38758 /* GTMGatherInputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FEE17991C03DB5900A38758 /* GTMGatherInputStream.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
-		4FEE17AB1C03DB5900A38758 /* GTMMIMEDocument.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FEE179A1C03DB5900A38758 /* GTMMIMEDocument.h */; };
+		4FEE17AB1C03DB5900A38758 /* GTMMIMEDocument.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FEE179A1C03DB5900A38758 /* GTMMIMEDocument.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4FEE17AC1C03DB5900A38758 /* GTMMIMEDocument.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FEE179B1C03DB5900A38758 /* GTMMIMEDocument.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		4FEE17AD1C03DB5900A38758 /* GTMMIMEDocument.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FEE179B1C03DB5900A38758 /* GTMMIMEDocument.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		4FEE17AE1C03DB5900A38758 /* GTMMIMEDocument.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FEE179B1C03DB5900A38758 /* GTMMIMEDocument.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		4FEE17AF1C03DB5900A38758 /* GTMMIMEDocument.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FEE179B1C03DB5900A38758 /* GTMMIMEDocument.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
-		4FEE17B01C03DB5900A38758 /* GTMReadMonitorInputStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FEE179C1C03DB5900A38758 /* GTMReadMonitorInputStream.h */; };
+		4FEE17B01C03DB5900A38758 /* GTMReadMonitorInputStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FEE179C1C03DB5900A38758 /* GTMReadMonitorInputStream.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4FEE17B11C03DB5900A38758 /* GTMReadMonitorInputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FEE179D1C03DB5900A38758 /* GTMReadMonitorInputStream.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		4FEE17B21C03DB5900A38758 /* GTMReadMonitorInputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FEE179D1C03DB5900A38758 /* GTMReadMonitorInputStream.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		4FEE17B31C03DB5900A38758 /* GTMReadMonitorInputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FEE179D1C03DB5900A38758 /* GTMReadMonitorInputStream.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		4FEE17B41C03DB5900A38758 /* GTMReadMonitorInputStream.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FEE179D1C03DB5900A38758 /* GTMReadMonitorInputStream.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
-		4FEE17B51C03DB5900A38758 /* GTMSessionFetcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FEE179E1C03DB5900A38758 /* GTMSessionFetcher.h */; };
+		4FEE17B51C03DB5900A38758 /* GTMSessionFetcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FEE179E1C03DB5900A38758 /* GTMSessionFetcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4FEE17B61C03DB5900A38758 /* GTMSessionFetcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FEE179F1C03DB5900A38758 /* GTMSessionFetcher.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		4FEE17B71C03DB5900A38758 /* GTMSessionFetcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FEE179F1C03DB5900A38758 /* GTMSessionFetcher.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		4FEE17B81C03DB5900A38758 /* GTMSessionFetcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FEE179F1C03DB5900A38758 /* GTMSessionFetcher.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		4FEE17B91C03DB5900A38758 /* GTMSessionFetcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FEE179F1C03DB5900A38758 /* GTMSessionFetcher.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
-		4FEE17BA1C03DB5900A38758 /* GTMSessionFetcherLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FEE17A01C03DB5900A38758 /* GTMSessionFetcherLogging.h */; };
+		4FEE17BA1C03DB5900A38758 /* GTMSessionFetcherLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FEE17A01C03DB5900A38758 /* GTMSessionFetcherLogging.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4FEE17BB1C03DB5900A38758 /* GTMSessionFetcherLogging.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FEE17A11C03DB5900A38758 /* GTMSessionFetcherLogging.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		4FEE17BC1C03DB5900A38758 /* GTMSessionFetcherLogging.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FEE17A11C03DB5900A38758 /* GTMSessionFetcherLogging.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		4FEE17BD1C03DB5900A38758 /* GTMSessionFetcherLogging.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FEE17A11C03DB5900A38758 /* GTMSessionFetcherLogging.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		4FEE17BE1C03DB5900A38758 /* GTMSessionFetcherLogging.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FEE17A11C03DB5900A38758 /* GTMSessionFetcherLogging.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
-		4FEE17BF1C03DB5900A38758 /* GTMSessionFetcherService.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FEE17A21C03DB5900A38758 /* GTMSessionFetcherService.h */; };
+		4FEE17BF1C03DB5900A38758 /* GTMSessionFetcherService.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FEE17A21C03DB5900A38758 /* GTMSessionFetcherService.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4FEE17C01C03DB5900A38758 /* GTMSessionFetcherService.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FEE17A31C03DB5900A38758 /* GTMSessionFetcherService.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		4FEE17C11C03DB5900A38758 /* GTMSessionFetcherService.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FEE17A31C03DB5900A38758 /* GTMSessionFetcherService.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		4FEE17C21C03DB5900A38758 /* GTMSessionFetcherService.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FEE17A31C03DB5900A38758 /* GTMSessionFetcherService.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		4FEE17C31C03DB5900A38758 /* GTMSessionFetcherService.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FEE17A31C03DB5900A38758 /* GTMSessionFetcherService.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
-		4FEE17C41C03DB5900A38758 /* GTMSessionUploadFetcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FEE17A41C03DB5900A38758 /* GTMSessionUploadFetcher.h */; };
+		4FEE17C41C03DB5900A38758 /* GTMSessionUploadFetcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 4FEE17A41C03DB5900A38758 /* GTMSessionUploadFetcher.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4FEE17C51C03DB5900A38758 /* GTMSessionUploadFetcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FEE17A51C03DB5900A38758 /* GTMSessionUploadFetcher.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		4FEE17C61C03DB5900A38758 /* GTMSessionUploadFetcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FEE17A51C03DB5900A38758 /* GTMSessionUploadFetcher.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
 		4FEE17C71C03DB5900A38758 /* GTMSessionUploadFetcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 4FEE17A51C03DB5900A38758 /* GTMSessionUploadFetcher.m */; settings = {COMPILER_FLAGS = "-fobjc-arc"; }; };
@@ -243,7 +243,7 @@
 		4F31A3D6142AA6BA00A58EAD /* TaskBatchPage1b.response.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = TaskBatchPage1b.response.txt; path = Tests/Data/TaskBatchPage1b.response.txt; sourceTree = "<group>"; };
 		4F35B4B01385F9270082F64E /* Task1.rest.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Task1.rest.txt; path = Tests/Data/Task1.rest.txt; sourceTree = "<group>"; };
 		4F35D4B3117787F600BDFA97 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = /System/Library/Frameworks/SystemConfiguration.framework; sourceTree = "<absolute>"; };
-		4F38F6A60B66E91D00B24B81 /* GTLOSXCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = GTLOSXCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4F38F6A60B66E91D00B24B81 /* GTL.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = GTL.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4F3DE994119CCE49006926D1 /* GTLDefines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GTLDefines.h; sourceTree = "<group>"; };
 		4F4DE9071371DD6F00F5C554 /* TaskError1.request.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = TaskError1.request.txt; path = Tests/Data/TaskError1.request.txt; sourceTree = "<group>"; };
 		4F4DE9081371DD6F00F5C554 /* TaskError1.response.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = TaskError1.response.txt; path = Tests/Data/TaskError1.response.txt; sourceTree = "<group>"; };
@@ -424,7 +424,7 @@
 		19C28FB8FE9D52D311CA2CBB /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				4F38F6A60B66E91D00B24B81 /* GTLOSXCore.framework */,
+				4F38F6A60B66E91D00B24B81 /* GTL.framework */,
 				4F1AD9020B71603F00DC0485 /* OSXDevTool */,
 				4F12027D11A4CA2F00BEB470 /* GTLUnitTests.xctest */,
 				F4368F721B8233BF00E17643 /* GTLiOSUnitTests.xctest */,
@@ -662,30 +662,30 @@
 			buildActionMask = 2147483647;
 			files = (
 				4F3DE995119CCE49006926D1 /* GTLDefines.h in Headers */,
-				4F697FA7131C1A4100A5AB6A /* GTMOAuth2Authentication.h in Headers */,
-				4F697FA9131C1A4100A5AB6A /* GTMOAuth2SignIn.h in Headers */,
-				4F697FB7131C1A5800A5AB6A /* GTMOAuth2WindowController.h in Headers */,
-				4FEE17BA1C03DB5900A38758 /* GTMSessionFetcherLogging.h in Headers */,
 				4FDE223C13848173005AEFAA /* GTLFramework.h in Headers */,
 				4FDE223E13848173005AEFAA /* GTLJSONParser.h in Headers */,
-				4FEE17BF1C03DB5900A38758 /* GTMSessionFetcherService.h in Headers */,
 				4FDE224013848173005AEFAA /* GTLTargetNamespace.h in Headers */,
 				4FDE224113848173005AEFAA /* GTLUtilities.h in Headers */,
 				4FDE22611384818E005AEFAA /* GTLBatchQuery.h in Headers */,
-				4FEE17A61C03DB5900A38758 /* GTMGatherInputStream.h in Headers */,
 				4FDE22631384818E005AEFAA /* GTLBatchResult.h in Headers */,
-				4FEE17B01C03DB5900A38758 /* GTMReadMonitorInputStream.h in Headers */,
-				4FEE17AB1C03DB5900A38758 /* GTMMIMEDocument.h in Headers */,
 				4FDE22651384818E005AEFAA /* GTLDateTime.h in Headers */,
 				4FDE22671384818E005AEFAA /* GTLErrorObject.h in Headers */,
 				4FDE22691384818E005AEFAA /* GTLObject.h in Headers */,
 				4FDE226B1384818E005AEFAA /* GTLQuery.h in Headers */,
 				4FDE226D1384818E005AEFAA /* GTLRuntimeCommon.h in Headers */,
 				4FDE226F1384818E005AEFAA /* GTLService.h in Headers */,
-				4FEE17C41C03DB5900A38758 /* GTMSessionUploadFetcher.h in Headers */,
-				4FEE17B51C03DB5900A38758 /* GTMSessionFetcher.h in Headers */,
 				4F0C4FBC13CFA7E5007E5E92 /* GTLUploadParameters.h in Headers */,
 				4F934E671512712100C4EA34 /* GTLBase64.h in Headers */,
+				4FEE17B51C03DB5900A38758 /* GTMSessionFetcher.h in Headers */,
+				4FEE17BF1C03DB5900A38758 /* GTMSessionFetcherService.h in Headers */,
+				4FEE17C41C03DB5900A38758 /* GTMSessionUploadFetcher.h in Headers */,
+				4FEE17BA1C03DB5900A38758 /* GTMSessionFetcherLogging.h in Headers */,
+				4FEE17A61C03DB5900A38758 /* GTMGatherInputStream.h in Headers */,
+				4FEE17B01C03DB5900A38758 /* GTMReadMonitorInputStream.h in Headers */,
+				4FEE17AB1C03DB5900A38758 /* GTMMIMEDocument.h in Headers */,
+				4F697FA7131C1A4100A5AB6A /* GTMOAuth2Authentication.h in Headers */,
+				4F697FA9131C1A4100A5AB6A /* GTMOAuth2SignIn.h in Headers */,
+				4F697FB7131C1A5800A5AB6A /* GTMOAuth2WindowController.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -699,7 +699,6 @@
 				4F14A9D80B1276B70072EBB8 /* Resources */,
 				4F14A9D90B1276B70072EBB8 /* Sources */,
 				4F14A9DA0B1276B70072EBB8 /* Frameworks */,
-				4F14A9DB0B1276B70072EBB8 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -742,7 +741,7 @@
 			);
 			name = GTLOSXCore;
 			productName = GTLOSXCore;
-			productReference = 4F38F6A60B66E91D00B24B81 /* GTLOSXCore.framework */;
+			productReference = 4F38F6A60B66E91D00B24B81 /* GTL.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		F4368F711B8233BF00E17643 /* GTLiOSUnitTests */ = {
@@ -768,7 +767,7 @@
 		089C1669FE841209C02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0630;
+				LastUpgradeCheck = 0720;
 				TargetAttributes = {
 					F4368F711B8233BF00E17643 = {
 						CreatedOnToolsVersion = 6.3.2;
@@ -867,23 +866,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		4F14A9DB0B1276B70072EBB8 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# Run the unit tests in this test bundle.\n\"${SYSTEM_DEVELOPER_DIR}/Tools/RunUnitTests\"\n";
-			showEnvVarsInLog = 0;
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		4F14A9D90B1276B70072EBB8 /* Sources */ = {
@@ -1066,6 +1048,7 @@
 				DEAD_CODE_STRIPPING = NO;
 				DEPLOYMENT_POSTPROCESSING = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -1179,6 +1162,7 @@
 					"-framework",
 					Cocoa,
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.GTLUnitTests;
 				PRODUCT_NAME = GTLUnitTests;
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				STRIP_STYLE = "non-global";
@@ -1205,6 +1189,7 @@
 					"-framework",
 					Cocoa,
 				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.GTLUnitTests;
 				PRODUCT_NAME = GTLUnitTests;
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				STRIP_STYLE = "non-global";
@@ -1216,6 +1201,7 @@
 			buildSettings = {
 				INFOPLIST_FILE = "Resources/DevTestTool-Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_BUNDLE_IDENTIFIER = com.yourcompany.DevelopmentTestApplication;
 				PRODUCT_NAME = OSXDevTool;
 			};
 			name = Debug;
@@ -1225,6 +1211,7 @@
 			buildSettings = {
 				INFOPLIST_FILE = "Resources/DevTestTool-Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_BUNDLE_IDENTIFIER = com.yourcompany.DevelopmentTestApplication;
 				PRODUCT_NAME = OSXDevTool;
 			};
 			name = Release;
@@ -1246,7 +1233,8 @@
 					"-framework",
 					AppKit,
 				);
-				PRODUCT_NAME = GTLOSXCore;
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.GTL;
+				PRODUCT_NAME = GTL;
 				STRIP_STYLE = "non-global";
 			};
 			name = Debug;
@@ -1268,7 +1256,8 @@
 					"-framework",
 					AppKit,
 				);
-				PRODUCT_NAME = GTLOSXCore;
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.GTL;
+				PRODUCT_NAME = GTL;
 				STRIP_STYLE = "non-global";
 			};
 			name = Release;
@@ -1277,10 +1266,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -1289,6 +1274,7 @@
 				INFOPLIST_FILE = "Resources/GTLUnitTests-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.GTLUnitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 			};
@@ -1299,14 +1285,11 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				COPY_PHASE_STRIP = NO;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = "Resources/GTLUnitTests-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = com.google.GTLUnitTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;

--- a/Source/GTLCore.xcodeproj/xcshareddata/xcschemes/OS X Dev Tool.xcscheme
+++ b/Source/GTLCore.xcodeproj/xcshareddata/xcschemes/OS X Dev Tool.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0630"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -23,10 +23,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -48,15 +48,18 @@
             ReferencedContainer = "container:GTLCore.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
@@ -72,10 +75,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/Source/GTLCore.xcodeproj/xcshareddata/xcschemes/OS X Framework and Tests.xcscheme
+++ b/Source/GTLCore.xcodeproj/xcshareddata/xcschemes/OS X Framework and Tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0630"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "4F38F6A50B66E91D00B24B81"
-               BuildableName = "GTLOSXCore.framework"
+               BuildableName = "GTL.framework"
                BlueprintName = "GTLOSXCore"
                ReferencedContainer = "container:GTLCore.xcodeproj">
             </BuildableReference>
@@ -44,7 +44,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "4F38F6A50B66E91D00B24B81"
-            BuildableName = "GTLOSXCore.framework"
+            BuildableName = "GTL.framework"
             BlueprintName = "GTLOSXCore"
             ReferencedContainer = "container:GTLCore.xcodeproj">
          </BuildableReference>
@@ -66,7 +66,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "4F38F6A50B66E91D00B24B81"
-            BuildableName = "GTLOSXCore.framework"
+            BuildableName = "GTL.framework"
             BlueprintName = "GTLOSXCore"
             ReferencedContainer = "container:GTLCore.xcodeproj">
          </BuildableReference>
@@ -84,7 +84,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "4F38F6A50B66E91D00B24B81"
-            BuildableName = "GTLOSXCore.framework"
+            BuildableName = "GTL.framework"
             BlueprintName = "GTLOSXCore"
             ReferencedContainer = "container:GTLCore.xcodeproj">
          </BuildableReference>

--- a/Source/GTLCore.xcodeproj/xcshareddata/xcschemes/iOS UnitTests.xcscheme
+++ b/Source/GTLCore.xcodeproj/xcshareddata/xcschemes/iOS UnitTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0630"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Source/Resources/DevTestTool-Info.plist
+++ b/Source/Resources/DevTestTool-Info.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.yourcompany.DevelopmentTestApplication</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>

--- a/Source/Resources/GTLOSXFramework-Info.plist
+++ b/Source/Resources/GTLOSXFramework-Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.google.GTLOSXCore</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>

--- a/Source/Resources/GTLUnitTests-Info.plist
+++ b/Source/Resources/GTLUnitTests-Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.google.GTLUnitTests</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>

--- a/Source/Tools/ServiceGenerator/ServiceGenerator.xcodeproj/project.pbxproj
+++ b/Source/Tools/ServiceGenerator/ServiceGenerator.xcodeproj/project.pbxproj
@@ -105,6 +105,7 @@
 			isa = PBXGroup;
 			children = (
 				08FB7795FE84155DC02AAC07 /* Source */,
+				F4CAA7BA1C3AFC4D00671BB2 /* Deps */,
 				08FB779DFE84155DC02AAC07 /* External Frameworks and Libraries */,
 				1AB674ADFE9D54B511CA2CBB /* Products */,
 			);
@@ -189,7 +190,7 @@
 			name = "GTL Sources";
 			sourceTree = "<group>";
 		};
-		F4BB4A4F12B7BF02008B2FB4 /* HTTPFetcher */ = {
+		F4BB4A4F12B7BF02008B2FB4 /* SessionFetcher */ = {
 			isa = PBXGroup;
 			children = (
 				4F5991251B03F69000FBCF22 /* GTMSessionFetcher.h */,
@@ -199,8 +200,8 @@
 				4F5991291B03F69000FBCF22 /* GTMSessionFetcherService.h */,
 				4F59912A1B03F69000FBCF22 /* GTMSessionFetcherService.m */,
 			);
-			name = HTTPFetcher;
-			path = "../../../Deps/gtm-session-fetcher/Source";
+			name = SessionFetcher;
+			path = "gtm-session-fetcher/Source";
 			sourceTree = "<group>";
 		};
 		F4BB4A7D12B7BF3E008B2FB4 /* Common */ = {
@@ -209,7 +210,6 @@
 				F4BB4A7F12B7BF4F008B2FB4 /* GTLDefines.h */,
 				F40E713B1384B41200EE3F02 /* Utilities */,
 				F40E712A1384B41200EE3F02 /* Objects */,
-				F4BB4A4F12B7BF02008B2FB4 /* HTTPFetcher */,
 			);
 			name = Common;
 			sourceTree = "<group>";
@@ -221,6 +221,15 @@
 				4F4B41231728C4A900A58B39 /* GTLDiscovery_Sources.m */,
 			);
 			name = Discovery;
+			sourceTree = "<group>";
+		};
+		F4CAA7BA1C3AFC4D00671BB2 /* Deps */ = {
+			isa = PBXGroup;
+			children = (
+				F4BB4A4F12B7BF02008B2FB4 /* SessionFetcher */,
+			);
+			name = Deps;
+			path = ../../../Deps;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -250,7 +259,7 @@
 		08FB7793FE84155DC02AAC07 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0630;
+				LastUpgradeCheck = 0720;
 			};
 			buildConfigurationList = 1DEB927808733DD40010E9CD /* Build configuration list for PBXProject "ServiceGenerator" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -322,6 +331,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_STATIC_ANALYZER_MODE = deep;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = DEBUG;

--- a/Source/Tools/ServiceGenerator/ServiceGenerator.xcodeproj/xcshareddata/xcschemes/ServiceGenerator.xcscheme
+++ b/Source/Tools/ServiceGenerator/ServiceGenerator.xcodeproj/xcshareddata/xcschemes/ServiceGenerator.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0630"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -23,10 +23,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
       <MacroExpansion>
@@ -38,15 +38,18 @@
             ReferencedContainer = "container:ServiceGenerator.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">
@@ -62,10 +65,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">


### PR DESCRIPTION
- Let Xcode update the projects/schemes.
- Small tweak to ServiceGenerator to make the project layout match the Core project.
- Rename the OS X Framework to be GTL so when an iOS framework gets added the include paths will be the same for sources.
- Remove a stale framework search path that trips a warning from Xcode 7.2