### PR TITLE
Blogger example: fixes build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,26 @@
-Source/GTLCore.xcodeproj/project.xcworkspace/xcuserdata
-Source/GTLCore.xcodeproj/xcuserdata
-Source/Tools/ServiceGenerator/ServiceGenerator.xcodeproj/project.xcworkspace/xcuserdata
-Source/Tools/ServiceGenerator/ServiceGenerator.xcodeproj/xcuserdata
-Source/Tools/ServiceGenerator/build
+## Build generated
+build/
+DerivedData/
+
+## Various settings
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata/
+
+## Other
+*.moved-aside
+*.xccheckout
+*.xcscmblueprint
+
+## Obj-C/Swift specific
+*.hmap
+*.ipa
 
 # Any place they exist.
 .DS_Store

--- a/Examples/BloggerSample/BloggerSample.xcodeproj/project.pbxproj
+++ b/Examples/BloggerSample/BloggerSample.xcodeproj/project.pbxproj
@@ -8,8 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		4F22A2151186315400FFBAB6 /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4F22A2141186315400FFBAB6 /* WebKit.framework */; };
-		4F2445C8121F0D2900FEE1DA /* GTL.framework in Copy GTL Framework */ = {isa = PBXBuildFile; fileRef = 4F2445BE121F0CF600FEE1DA /* GTL.framework */; };
-		4F2445C9121F0D2C00FEE1DA /* GTL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4F2445BE121F0CF600FEE1DA /* GTL.framework */; };
 		4F385CB61807669C00E21D98 /* GTLBlogger_Sources.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F385CB51807669C00E21D98 /* GTLBlogger_Sources.m */; };
 		4F9A73431578159900D7D1B5 /* BloggerSampleAppController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F9A73401578159900D7D1B5 /* BloggerSampleAppController.m */; };
 		4F9A73441578159900D7D1B5 /* BloggerSampleWindowController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4F9A73421578159900D7D1B5 /* BloggerSampleWindowController.m */; };
@@ -18,43 +16,44 @@
 		8D11072B0486CEB800E47090 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 089C165CFE840E0CC02AAC07 /* InfoPlist.strings */; };
 		8D11072D0486CEB800E47090 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 29B97316FDCFA39411CA2CEA /* main.m */; settings = {ATTRIBUTES = (); }; };
 		8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1058C7A1FEA54F0111CA2CBB /* Cocoa.framework */; };
+		E89546401C7E801200C24D38 /* GTL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E89546311C7E7EEF00C24D38 /* GTL.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		4F2445BD121F0CF600FEE1DA /* PBXContainerItemProxy */ = {
+		E89546301C7E7EEF00C24D38 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 4F2445B6121F0CF600FEE1DA /* GTL.xcodeproj */;
+			containerPortal = 4F2445B6121F0CF600FEE1DA /* GTLCore.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = 4F38F6A60B66E91D00B24B81;
-			remoteInfo = GTLFramework;
+			remoteInfo = GTLOSXCore;
 		};
-		4F2445BF121F0CF600FEE1DA /* PBXContainerItemProxy */ = {
+		E89546321C7E7EEF00C24D38 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 4F2445B6121F0CF600FEE1DA /* GTL.xcodeproj */;
+			containerPortal = 4F2445B6121F0CF600FEE1DA /* GTLCore.xcodeproj */;
 			proxyType = 2;
-			remoteGlobalIDString = 4F12027C11A4CA2F00BEB470;
-			remoteInfo = GTLTouchStaticLib;
+			remoteGlobalIDString = F4469DB41C40229D00BCFAA1;
+			remoteInfo = GTLiOSCore;
 		};
-		4F2445C1121F0CF600FEE1DA /* PBXContainerItemProxy */ = {
+		E89546341C7E7EEF00C24D38 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 4F2445B6121F0CF600FEE1DA /* GTL.xcodeproj */;
+			containerPortal = 4F2445B6121F0CF600FEE1DA /* GTLCore.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = F4368F721B8233BF00E17643;
+			remoteInfo = GTLiOSUnitTests;
+		};
+		E89546361C7E7EEF00C24D38 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 4F2445B6121F0CF600FEE1DA /* GTLCore.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = 4F12027D11A4CA2F00BEB470;
-			remoteInfo = GTLUnitTests;
+			remoteInfo = GTLOSXUnitTests;
 		};
-		4F2445C3121F0CF600FEE1DA /* PBXContainerItemProxy */ = {
+		E89546381C7E7EEF00C24D38 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 4F2445B6121F0CF600FEE1DA /* GTL.xcodeproj */;
+			containerPortal = 4F2445B6121F0CF600FEE1DA /* GTLCore.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = 4F1AD9020B71603F00DC0485;
-			remoteInfo = DevelopmentTestTool;
-		};
-		4F72439E12233FAF001A4AD0 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 4F2445B6121F0CF600FEE1DA /* GTL.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = 4F38F6A50B66E91D00B24B81;
-			remoteInfo = GTLFramework;
+			remoteInfo = OSXDevTool;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -65,7 +64,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				4F2445C8121F0D2900FEE1DA /* GTL.framework in Copy GTL Framework */,
 			);
 			name = "Copy GTL Framework";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -79,7 +77,7 @@
 		29B97324FDCFA39411CA2CEA /* AppKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AppKit.framework; path = /System/Library/Frameworks/AppKit.framework; sourceTree = "<absolute>"; };
 		29B97325FDCFA39411CA2CEA /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = /System/Library/Frameworks/Foundation.framework; sourceTree = "<absolute>"; };
 		4F22A2141186315400FFBAB6 /* WebKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WebKit.framework; path = /System/Library/Frameworks/WebKit.framework; sourceTree = "<absolute>"; };
-		4F2445B6121F0CF600FEE1DA /* GTL.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = GTL.xcodeproj; path = ../../Source/GTL.xcodeproj; sourceTree = SOURCE_ROOT; };
+		4F2445B6121F0CF600FEE1DA /* GTLCore.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = GTLCore.xcodeproj; path = ../../Source/GTLCore.xcodeproj; sourceTree = SOURCE_ROOT; };
 		4F385CB51807669C00E21D98 /* GTLBlogger_Sources.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GTLBlogger_Sources.m; sourceTree = "<group>"; };
 		4F9A733F1578159900D7D1B5 /* BloggerSampleAppController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = BloggerSampleAppController.h; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		4F9A73401578159900D7D1B5 /* BloggerSampleAppController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = BloggerSampleAppController.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
@@ -97,7 +95,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4F2445C9121F0D2C00FEE1DA /* GTL.framework in Frameworks */,
+				E89546401C7E801200C24D38 /* GTL.framework in Frameworks */,
 				8D11072F0486CEB800E47090 /* Cocoa.framework in Frameworks */,
 				4F22A2151186315400FFBAB6 /* WebKit.framework in Frameworks */,
 			);
@@ -146,7 +144,7 @@
 		29B97314FDCFA39411CA2CEA /* CalendarSample */ = {
 			isa = PBXGroup;
 			children = (
-				4F2445B6121F0CF600FEE1DA /* GTL.xcodeproj */,
+				4F2445B6121F0CF600FEE1DA /* GTLCore.xcodeproj */,
 				080E96DDFE201D6D7F000001 /* Classes */,
 				4FB25385138C3F9E00B5C1AE /* API Services */,
 				29B97315FDCFA39411CA2CEA /* Other Sources */,
@@ -186,17 +184,6 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		4F2445B7121F0CF600FEE1DA /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				4F2445BE121F0CF600FEE1DA /* GTL.framework */,
-				4F2445C0121F0CF600FEE1DA /* libGTLTouchStaticLib.a */,
-				4F2445C2121F0CF600FEE1DA /* GTLUnitTests.octest */,
-				4F2445C4121F0CF600FEE1DA /* DevelopmentTestTool */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 		4FAB9B42157951EF000529A7 /* Generated */ = {
 			isa = PBXGroup;
 			children = (
@@ -222,6 +209,18 @@
 			name = "Build Scripts";
 			sourceTree = "<group>";
 		};
+		E89546291C7E7EEF00C24D38 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				E89546311C7E7EEF00C24D38 /* GTL.framework */,
+				E89546331C7E7EEF00C24D38 /* GTL.framework */,
+				E89546351C7E7EEF00C24D38 /* GTLiOSUnitTests.xctest */,
+				E89546371C7E7EEF00C24D38 /* GTLUnitTests.xctest */,
+				E89546391C7E7EEF00C24D38 /* OSXDevTool */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -238,7 +237,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				4F72439F12233FAF001A4AD0 /* PBXTargetDependency */,
 			);
 			name = BloggerSample;
 			productInstallPath = "$(HOME)/Applications";
@@ -252,6 +250,7 @@
 		29B97313FDCFA39411CA2CEA /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastUpgradeCheck = 0720;
 			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "BloggerSample" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -267,8 +266,8 @@
 			projectDirPath = "";
 			projectReferences = (
 				{
-					ProductGroup = 4F2445B7121F0CF600FEE1DA /* Products */;
-					ProjectRef = 4F2445B6121F0CF600FEE1DA /* GTL.xcodeproj */;
+					ProductGroup = E89546291C7E7EEF00C24D38 /* Products */;
+					ProjectRef = 4F2445B6121F0CF600FEE1DA /* GTLCore.xcodeproj */;
 				},
 			);
 			projectRoot = "";
@@ -279,32 +278,39 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
-		4F2445BE121F0CF600FEE1DA /* GTL.framework */ = {
+		E89546311C7E7EEF00C24D38 /* GTL.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
 			path = GTL.framework;
-			remoteRef = 4F2445BD121F0CF600FEE1DA /* PBXContainerItemProxy */;
+			remoteRef = E89546301C7E7EEF00C24D38 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		4F2445C0121F0CF600FEE1DA /* libGTLTouchStaticLib.a */ = {
+		E89546331C7E7EEF00C24D38 /* GTL.framework */ = {
 			isa = PBXReferenceProxy;
-			fileType = archive.ar;
-			path = libGTLTouchStaticLib.a;
-			remoteRef = 4F2445BF121F0CF600FEE1DA /* PBXContainerItemProxy */;
+			fileType = wrapper.framework;
+			path = GTL.framework;
+			remoteRef = E89546321C7E7EEF00C24D38 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		4F2445C2121F0CF600FEE1DA /* GTLUnitTests.octest */ = {
+		E89546351C7E7EEF00C24D38 /* GTLiOSUnitTests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
-			path = GTLUnitTests.octest;
-			remoteRef = 4F2445C1121F0CF600FEE1DA /* PBXContainerItemProxy */;
+			path = GTLiOSUnitTests.xctest;
+			remoteRef = E89546341C7E7EEF00C24D38 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		4F2445C4121F0CF600FEE1DA /* DevelopmentTestTool */ = {
+		E89546371C7E7EEF00C24D38 /* GTLUnitTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = GTLUnitTests.xctest;
+			remoteRef = E89546361C7E7EEF00C24D38 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		E89546391C7E7EEF00C24D38 /* OSXDevTool */ = {
 			isa = PBXReferenceProxy;
 			fileType = "compiled.mach-o.executable";
-			path = DevelopmentTestTool;
-			remoteRef = 4F2445C3121F0CF600FEE1DA /* PBXContainerItemProxy */;
+			path = OSXDevTool;
+			remoteRef = E89546381C7E7EEF00C24D38 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -353,14 +359,6 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
-/* Begin PBXTargetDependency section */
-		4F72439F12233FAF001A4AD0 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = GTLFramework;
-			targetProxy = 4F72439E12233FAF001A4AD0 /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
-
 /* Begin PBXVariantGroup section */
 		089C165CFE840E0CC02AAC07 /* InfoPlist.strings */ = {
 			isa = PBXVariantGroup;
@@ -392,10 +390,12 @@
 		C01FCF4B08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				INFOPLIST_FILE = Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.BloggerSample;
 				PRODUCT_NAME = BloggerSample;
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				WRAPPER_EXTENSION = app;
@@ -405,8 +405,10 @@
 		C01FCF4C08A954540054247B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
 				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
 				INFOPLIST_FILE = Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = com.example.BloggerSample;
 				PRODUCT_NAME = BloggerSample;
 				WRAPPER_EXTENSION = app;
 			};
@@ -415,10 +417,12 @@
 		C01FCF4F08A954540054247B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = c99;
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				ONLY_ACTIVE_ARCH = YES;
 				OTHER_CFLAGS = (
 					"-DGTL_BUILT_AS_FRAMEWORK=1",
 					"-DDEBUG=1",

--- a/Examples/BloggerSample/BloggerSample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Examples/BloggerSample/BloggerSample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Examples/BloggerSample/BloggerSampleWindowController.m
+++ b/Examples/BloggerSample/BloggerSampleWindowController.m
@@ -20,7 +20,7 @@
 #import "BloggerSampleWindowController.h"
 
 #import "GTL/GTLUtilities.h"
-#import "GTL/GTMHTTPFetcherLogging.h"
+#import "GTL/GTMSessionFetcherLogging.h"
 
 @interface BloggerSampleWindowController ()
 
@@ -213,7 +213,7 @@ NSString *const kKeychainItemName = @"BloggerSample: Google Blogger";
 }
 
 - (IBAction)loggingCheckboxClicked:(id)sender {
-  [GTMHTTPFetcher setLoggingEnabled:[sender state]];
+  [GTMSessionFetcher setLoggingEnabled:[sender state]];
 }
 
 #pragma mark -

--- a/Examples/BloggerSample/Info.plist
+++ b/Examples/BloggerSample/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleIconFile</key>
 	<string></string>
 	<key>CFBundleIdentifier</key>
-	<string>com.example.BloggerSample</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
The Blogger example was not building for me when I checked out the repository. I had to point the project to the new location of the GTLCore.xcodeproj (it was GTL.xcodeproj).

GTMHTTPFetcher isn't used anymore, so I changed the example to use GTMSessionFetcher.

Likely the other examples will need similar changes.

Since I wasn't sure which files from the BloggerSample.xcodeproj to include, I also modified .gitignore to match the recommended settings at https://github.com/github/gitignore/blob/master/Objective-C.gitignore.