### PR TITLE
Fix two issues with the GTL pod

### DIFF
--- a/GoogleAPIClient.podspec
+++ b/GoogleAPIClient.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'GoogleAPIClient'
-  s.version      = '1.0.0'
+  s.version      = '1.0.1'
   s.author       = 'Google Inc.'
   s.homepage     = 'https://github.com/google/google-api-objectivec-client'
   s.license      = { :type => 'Apache', :file => 'LICENSE' }
@@ -16,6 +16,9 @@ Pod::Spec.new do |s|
                    DESC
   s.ios.deployment_target = '6.0'
   s.osx.deployment_target = '10.8'
+
+  s.user_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) GTL_USE_FRAMEWORK_IMPORTS=1' }
+  s.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) GTL_HAS_SESSION_UPLOAD_FETCHER_IMPORT=1' }
   s.requires_arc = false
   s.dependency 'GTMSessionFetcher', '~> 1.1'
 

--- a/Source/Objects/GTLService.h
+++ b/Source/Objects/GTLService.h
@@ -43,19 +43,33 @@
   #define GTL_USE_SESSION_FETCHER GTM_USE_SESSION_FETCHER
 #endif  // GTL_USE_SESSION_FETCHER
 
+#if !defined(GTL_USE_FRAMEWORK_IMPORTS)
+  #define GTL_USE_FRAMEWORK_IMPORTS 0
+#endif
+
 #if GTL_USE_SESSION_FETCHER
   #define GTLUploadFetcherClass GTMSessionUploadFetcher
   #define GTLUploadFetcherClassStr @"GTMSessionUploadFetcher"
 
-  #import "GTMSessionFetcher.h"
-  #import "GTMSessionFetcherService.h"
+  #if GTL_USE_FRAMEWORK_IMPORTS
+    #import <GTMSessionFetcher/GTMSessionFetcher.h>
+    #import <GTMSessionFetcher/GTMSessionFetcherService.h>
+  #else
+    #import "GTMSessionFetcher.h"
+    #import "GTMSessionFetcherService.h"
+  #endif  // GTL_USE_FRAMEWORK_IMPORTS
 #else
   // !GTL_USE_SESSION_FETCHER
   #define GTLUploadFetcherClass GTMHTTPUploadFetcher
   #define GTLUploadFetcherClassStr @"GTMHTTPUploadFetcher"
 
-  #import "GTMHTTPFetcher.h"
-  #import "GTMHTTPFetcherService.h"
+  #if GTL_USE_FRAMEWORK_IMPORTS
+    #import <GTMHTTPFetcher/GTMHTTPFetcher.h>
+    #import <GTMHTTPFetcher/GTMHTTPFetcherService.h>
+  #else
+    #import "GTMHTTPFetcher.h"
+    #import "GTMHTTPFetcherService.h"
+  #endif  // GTL_USE_FRAMEWORK_IMPORTS
 #endif  // GTL_USE_SESSION_FETCHER
 
 #import "GTLBatchQuery.h"

--- a/Source/Objects/GTLService.m
+++ b/Source/Objects/GTLService.m
@@ -79,6 +79,17 @@ static NSString *ETagIfPresent(GTLObject *obj) {
 }
 @end
 
+#if !defined(GTL_HAS_SESSION_UPLOAD_FETCHER_IMPORT)
+#define GTL_HAS_SESSION_UPLOAD_FETCHER_IMPORT 0
+#endif
+
+#if GTL_HAS_SESSION_UPLOAD_FETCHER_IMPORT
+#if GTL_USE_FRAMEWORK_IMPORTS
+  #import <GTMSessionFetcher/GTMSessionUploadFetcher.h>
+#else
+  #import "GTMSessionUploadFetcher.h"
+#endif // GTL_USE_FRAMEWORK_IMPORTS
+#else
 // If the upload fetcher class is available, it can be used for chunked uploads
 //
 // We locally declare some methods of the upload fetcher so we
@@ -123,7 +134,7 @@ static NSString *ETagIfPresent(GTLObject *obj) {
 - (void)resumeFetching;
 - (BOOL)isPaused;
 @end
-
+#endif  // GTL_HAS_SESSION_UPLOAD_FETCHER_IMPORT
 
 @interface GTLService ()
 - (void)prepareToParseObjectForFetcher:(GTMBridgeFetcher *)fetcher;


### PR DESCRIPTION
* Include the GTMSessionUploadFetcher header if available, based on a macro. 
* Import GTMSessionFetcher.h as a framework header, based on a macro.

These should fix the issues in #162. I've tested this locally with a library and framework integration, and with one of the GTL generated subspecs, and it compiles and links properly.