### PR TITLE
adding missing *required* info.plist version kvp’s

### DIFF
--- a/Source/Resources/GTLOSXFramework-Info.plist
+++ b/Source/Resources/GTLOSXFramework-Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0</string>
+	<string>1.0.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/Resources/GTLOSXFramework-Info.plist
+++ b/Source/Resources/GTLOSXFramework-Info.plist
@@ -12,9 +12,11 @@
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>2.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>2.0</string>
+	<string>1</string>
 </dict>
 </plist>

--- a/Source/Resources/GTLiOSFramework-Info.plist
+++ b/Source/Resources/GTLiOSFramework-Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0</string>
+	<string>1.0.5</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/Resources/GTLiOSFramework-Info.plist
+++ b/Source/Resources/GTLiOSFramework-Info.plist
@@ -12,9 +12,11 @@
 	<string>6.0</string>
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>2.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>2.0</string>
+	<string>1</string>
 </dict>
 </plist>


### PR DESCRIPTION
### Proposed Updates:

Updated the OSX and iOS plists to include both the  `CFBundleVersion` and `CFBundleShortVersionString`. I've also updated the values of each in accordance with what Apple's documentation specifies. Which says...

> CFBundleShortVersionString (String - iOS, macOS) specifies the release version number of the bundle, which identifies a released iteration of the app.
> 
> The release version number is a string composed of three period-separated integers. The first integer represents major revision to the app, such as a revision that implements new features or major changes. The second integer denotes a revision that implements less prominent features. The third integer represents a maintenance release revision.
> 
> The value for this key differs from the value for CFBundleVersion, which identifies an iteration (released or unreleased) of the app.

More info can be found here: https://developer.apple.com/library/content/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/uid/20001431-111349

The value of `CFBundleShortVersionString` has been set to `1.0.5` to match the latest release. When releasing `1.0.6` you'd need to update the Info.plist's `CFBundleShortVersionString` to match this. The value of `CFBundleVersion` has been set to `1`. The `CFBundleVersion` is just meant to be a build number indicator and isn't nearly as important as the `CFBundleShortVersionString`.

### Why is this important?

This is an important change to the plists because any resulting application which includes this framework cannot be submitted to Apple without receiving the following error, which blocks the submission and requires an update to the application.

> ERROR ITMS-90057: "The bundle 'Payload/MyApp.app/Frameworks/GTL.framework' is missing plist key. The Info.plist file is missing the required key: CFBundleShortVersionString."

Please consider this a rather serious issue. Currently, anyone wanting to include this framework in their application will need to either fork the repo and add the missing Info.plist key (`CFBundleShortVersionString`) and then point their application to their forked version. Or, they'll have to edit the xcarchive in place and add the missing key that way. 
